### PR TITLE
Disallow the blessed object to be bound

### DIFF
--- a/lib/SQL/NamedPlaceholder.pm
+++ b/lib/SQL/NamedPlaceholder.pm
@@ -3,7 +3,7 @@ package SQL::NamedPlaceholder;
 use strict;
 use warnings;
 use Exporter::Lite;
-use Scalar::Util qw(reftype);
+use Scalar::Util qw(reftype blessed);
 
 use Carp;
 
@@ -14,6 +14,8 @@ sub bind_named {
 	my ($sql, $hash) = @_;
 	$sql or croak 'my ($sql, $bind) = bind_named($sql, $hash) requires $sql';
 	(reftype($hash) || '') eq 'HASH' or croak 'must specify HASH as bind values';
+
+	croak 'blessed object cannot be bound' if grep { blessed($_) } values %$hash;
 
 	# replace question marks as placeholder. e.g. [`hoge` = ?] to [`hoge` = :hoge]
 	$sql =~ s{(([`"]?)(\S+?)\2\s*(=|<=?|>=?|<>|!=|<=>)\s*)\?}{$1:$3}g;

--- a/t/01_base.t
+++ b/t/01_base.t
@@ -102,6 +102,7 @@ subtest exceptions => sub {
 	like exception { bind_named('SELECT * FROM entry', undef) }, qr/must specify HASH/;
 	is exception { bind_named('SELECT * FROM entry', bless(+{}, 'Foo')) }, undef;
 	like exception { bind_named('SELECT * FROM entry WHERE id = ?', {}) }, qr/'id' does not exist in bind hash/;
+	like exception { bind_named('SELECT * FROM entry WHERE id = :user_id', { user_id => (bless {}, 't::user_id') }) }, qr/blessed object cannot be bound/;
 };
 
 done_testing;


### PR DESCRIPTION
This is kind of like type checking to keep away from a pitfall.
# Consideration
- This is a breaking change and so we should provide a way to disable this feature or not?
- We should take care of overload-ed objects?
