### PR TITLE
Disallow the time to be bound

### DIFF
--- a/lib/SQL/NamedPlaceholder.pm
+++ b/lib/SQL/NamedPlaceholder.pm
@@ -20,7 +20,7 @@ sub bind_named {
 
 	my $bind = [];
 
-	$sql =~ s{:(\w+)}{
+	$sql =~ s{:([A-Za-z_][A-Za-z0-9_]*)}{
 		croak("'$1' does not exist in bind hash") if !exists $hash->{$1};
 		my $type = ref($hash->{$1});
 		if ($type eq 'ARRAY') {


### PR DESCRIPTION
`\w+` matches `2016-02-02 00:00:00`. But, I think it is not good.
